### PR TITLE
update map annotation

### DIFF
--- a/src/main/annotations/updateMapAnnotation.m
+++ b/src/main/annotations/updateMapAnnotation.m
@@ -4,7 +4,7 @@ function ma = updateMapAnnotation(session, ma, keyvalue, varargin)
 %
 % SYNTAX
 % ma = updateMapAnnotation(session, ma, keyvalue)
-% ma = updateMapAnnotation(____,'Param',value)
+% ma = updateMapAnnotation(session,'Param',value)
 %
 % INPUT ARGUMENTS
 % session     omero.api.ServiceFactoryPrxHelper object
@@ -12,10 +12,10 @@ function ma = updateMapAnnotation(session, ma, keyvalue, varargin)
 % ma          MapAnnotationI object
 %
 % keyvalue    cell array of characters | string array
-%             The number of columns must be 2. The first colum is for keys
+%             The number of columns must be 2. The first column is for keys
 %             and the second column is for values.
 %
-% OPTIONAL PARA<ETER/VALUE PAIRS
+% OPTIONAL PARAMETER/VALUE PAIRS
 % 'namespace' char
 %             Namespace for the MapAnnotation. If you specify this, the
 %             value of 'iseditable' will be ignored.
@@ -86,7 +86,7 @@ end
 if isempty(ip.Results.namespace)
 
     if ip.Results.iseditable
-        %NOTE this is required to make it editable from GUI
+        % NOTE this is required to make it editable from GUI
         eval('import omero.constants.metadata.NSCLIENTMAPANNOTATION')
         ma.setNs(rstring(char(NSCLIENTMAPANNOTATION.value)));
     else
@@ -99,7 +99,7 @@ end
 
 
 
-%update the keys and values of the object
+% Update the keys and values of the object
 
 keys = cellstr(keyvalue(:,1));
 values = cellstr(keyvalue(:,2));

--- a/src/main/annotations/updateMapAnnotation.m
+++ b/src/main/annotations/updateMapAnnotation.m
@@ -1,0 +1,114 @@
+function ma = updateMapAnnotation(session, ma, keyvalue, varargin)
+% updateMapAnnotation will update the content (key-value pairs) of
+% MapAnnotation ma while maintaining its ID.
+%
+% SYNTAX
+% ma = updateMapAnnotation(session, ma, keyvalue)
+% ma = updateMapAnnotation(____,'Param',value)
+%
+% INPUT ARGUMENTS
+% session     omero.api.ServiceFactoryPrxHelper object
+%
+% ma          MapAnnotationI object
+%
+% keyvalue    cell array of characters | string array
+%             The number of columns must be 2. The first colum is for keys
+%             and the second column is for values.
+%
+% OPTIONAL PARA<ETER/VALUE PAIRS
+% 'namespace' char
+%             Namespace for the MapAnnotation. If you specify this, the
+%             value of 'iseditable' will be ignored.
+%
+% 'description'
+%             char
+%             Description for the MapAnnotation.
+%
+% 'group'     a positive integer
+%             group ID
+%
+% 'iseditable'
+%             false (default) | true | 0 | 1
+%             If true or 1, MapAnnotation (Key-Value Pairs) will
+%             be editable via GUI (OMERO.web or OMERO.insight). If you
+%             specify 'namespace', 'iseditable' will be ignored.
+%
+%
+% OUTPUT ARGUMENTS
+% ma          MapAnnotationI object
+%
+%
+% Written by Kouichi C. Nakamura Ph.D.
+% MRC Brain Network Dynamics Unit
+% University of Oxford
+% kouichi.c.nakamura@gmail.com
+% 05-Dec-2018 18:23:13
+%
+% See also
+% writeMapAnnotation, strToMapAnnotation, mapAnnotationToCellstr
+
+ip = inputParser;
+ip.addRequired('session',@(x) isscalar(x));
+ip.addRequired('ma',@(x) isa(x,'omero.model.MapAnnotationI'));
+ip.addRequired('keyvalue',@(x) isempty(x) || size(x,2) == 2 && (iscellstr(x) || isstring (x)));
+ip.addParameter('namespace', '', @ischar);
+ip.addParameter('description', '', @ischar);
+ip.addParameter('iseditable', false, @(x) isscalar(x) && x == 1 || x == 0);
+ip.addParameter('group', [], @(x) isscalar(x) && isnumeric(x));
+ip.parse(session, ma, keyvalue,varargin{:});
+
+
+context = java.util.HashMap;
+% Check if the Annotation exists on the server
+try
+    group = ma.getDetails().getGroup().getId().getValue();
+    context.put('omero.group', java.lang.String(num2str(group)));
+    if isempty(ip.Results.group)
+         index = length(varargin);
+         varargin{index + 1} = 'group';
+         varargin{index + 2} = group;
+    end
+catch
+end
+
+% In case the MapAnnotation does not yet exist on the server:
+if ~context.containsKey('omero.group') && ~isempty(ip.Results.group)
+    context.put(...
+        'omero.group', java.lang.String(num2str(ip.Results.group)));
+end
+
+
+if ~isempty(ip.Results.description)
+    ma.setDescription(rstring(ip.Results.description));
+end
+
+
+if isempty(ip.Results.namespace)
+
+    if ip.Results.iseditable
+        %NOTE this is required to make it editable from GUI
+        eval('import omero.constants.metadata.NSCLIENTMAPANNOTATION')
+        ma.setNs(rstring(char(NSCLIENTMAPANNOTATION.value)));
+    else
+        ma.setNs(rstring(char('')));
+    end
+
+else
+    ma.setNs(rstring(ip.Results.namespace))
+end
+
+
+
+%update the keys and values of the object
+
+keys = cellstr(keyvalue(:,1));
+values = cellstr(keyvalue(:,2));
+
+nv = java.util.ArrayList();
+for i = 1 : numel(keys)
+    nv.add(omero.model.NamedValue(keys{i}, values{i}));
+end
+ma.setMapValue(nv);
+
+ma = session.getUpdateService().saveAndReturnObject(...
+    ma,context);


### PR DESCRIPTION
Added ``updateMapAnnotation`` MATLAB function which allows you to change the content of a MapAnnotation object in OMERO server while keeping the ID of the object.

```matlab
function ma = updateMapAnnotation(session, ma, keyvalue, varargin)
% updateMapAnnotation will update the content (key-value pairs) of
% MapAnnotation ma while maintaining its ID.
%
% SYNTAX
% ma = updateMapAnnotation(session, ma, keyvalue)
% ma = updateMapAnnotation(____,'Param',value)
%
% INPUT ARGUMENTS
% session     omero.api.ServiceFactoryPrxHelper object
%
% ma          MapAnnotationI object
%
% keyvalue    cell array of characters | string array
%             The number of columns must be 2. The first colum is for keys
%             and the second column is for values.
%
% OPTIONAL PARA<ETER/VALUE PAIRS
% 'namespace' char
%             Namespace for the MapAnnotation. If you specify this, the
%             value of 'iseditable' will be ignored.
%
% 'description'
%             char
%             Description for the MapAnnotation. 
%
% 'group'     a positive integer
%             group ID
%
% 'iseditable' 
%             false (default) | true | 0 | 1 
%             If true or 1, MapAnnotation (Key-Value Pairs) will
%             be editable via GUI (OMERO.web or OMERO.insight). If you
%             specify 'namespace', 'iseditable' will be ignored.
%
%
% OUTPUT ARGUMENTS
% ma          MapAnnotationI object
%
%
% Written by Kouichi C. Nakamura Ph.D.
% MRC Brain Network Dynamics Unit
% University of Oxford
% kouichi.c.nakamura@gmail.com
% 05-Dec-2018 18:23:13
%
% See also
% writeMapAnnotation, strToMapAnnotation, mapAnnotationToCellstr

```


# Testing this PR

1. required setup: You need an image with MapAnnotation on OMERO server

2. actions to perform. 

```matlab
session = client.createSession(user, password);
ma1 = getObjectAnnotations(session, 'map', 'image', imageID)
s = string(mapAnnotationToCellstr(ma1))
s_ = ["New key","new value";s]
ma2 = updateMapAnnotation(session, ma1, s_, 'iseditable',true)

% check the MapAnnotation form GUI now
% Confirm that it is editable.

ma3 = getObjectAnnotations(session, 'map', 'image', imageID)
s = string(mapAnnotationToCellstr(ma3))
s_ = ["New key 2","new value 2";s]
ma4 = updateMapAnnotation(session, ma3, s_, 'iseditable',false)

% check the MapAnnotation form GUI now
% Confirm that it is editable.
```

You can find `mapAnnotationToCellstr` from [here](https://github.com/openmicroscopy/openmicroscopy/blob/5f23736f11228fce67133592c3bd69541eb0744c/components/tools/OmeroM/src/helper/mapAnnotationToCellstr.m)

3. expected observations

+ The MapAnnotation will be swtiched from editable to uneditable etc.
+ ID of the MapAnnotation will stay the same.
+ The new keys and values will be added to the MapAnnotation.


# Related reading

Link to cards, tickets, other PRs:

Originally included in https://github.com/openmicroscopy/openmicroscopy/pull/5925

